### PR TITLE
feat(): Add Rox.stream_keys/2

### DIFF
--- a/native/rox_nif/Cargo.lock
+++ b/native/rox_nif/Cargo.lock
@@ -3,7 +3,7 @@ name = "rox_nif"
 version = "0.1.0"
 dependencies = [
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocksdb 0.7.0 (git+https://github.com/urbint/rust-rocksdb.git)",
+ "rocksdb 0.8.1 (git+https://github.com/urbint/rust-rocksdb.git)",
  "rustler 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustler_codegen 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -12,6 +12,14 @@ dependencies = [
 name = "bitflags"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cc"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rayon 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "coco"
@@ -54,14 +62,6 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "gcc"
-version = "0.3.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rayon 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "lazy_static"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,10 +78,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.5.0"
-source = "git+https://github.com/urbint/rust-rocksdb.git#886863b7ea6ee17c3d27cb9c8dff6bf8e96a6049"
+version = "5.6.2"
+source = "git+https://github.com/urbint/rust-rocksdb.git#14ece658c3752ce5ef5953022e8ec8296456882d"
 dependencies = [
- "gcc 0.3.53 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "make-cmd 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -153,11 +153,11 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.7.0"
-source = "git+https://github.com/urbint/rust-rocksdb.git#886863b7ea6ee17c3d27cb9c8dff6bf8e96a6049"
+version = "0.8.1"
+source = "git+https://github.com/urbint/rust-rocksdb.git#14ece658c3752ce5ef5953022e8ec8296456882d"
 dependencies = [
  "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "librocksdb-sys 0.5.0 (git+https://github.com/urbint/rust-rocksdb.git)",
+ "librocksdb-sys 5.6.2 (git+https://github.com/urbint/rust-rocksdb.git)",
 ]
 
 [[package]]
@@ -221,17 +221,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
+"checksum cc 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ef4019bdb99c0c1ddd56c12c2f507c174d729c6915eca6bd9d27c42f3d93b0f4"
 "checksum coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c06169f5beb7e31c7c67ebf5540b8b472d23e3eade3b2ec7d1f5b504a85f91bd"
 "checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
 "checksum custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 "checksum either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18785c1ba806c258137c937e44ada9ee7e69a37e3c72077542cd2f069d78562a"
 "checksum erlang_nif-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6895d619f32e53b4e4ed02bd6a841de401111f60a6cf1e6b2cdbacf819a32841"
 "checksum futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "4b63a4792d4f8f686defe3b39b92127fea6344de5d38202b2ee5a11bbbf29d6a"
-"checksum gcc 0.3.53 (registry+https://github.com/rust-lang/crates.io-index)" = "e8310f7e9c890398b0e80e301c4f474e9918d2b27fca8f48486ca775fa9ffc5a"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
 "checksum libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)" = "8a014d9226c2cc402676fbe9ea2e15dd5222cd1dd57f576b5b283178c944a264"
-"checksum librocksdb-sys 0.5.0 (git+https://github.com/urbint/rust-rocksdb.git)" = "<none>"
+"checksum librocksdb-sys 5.6.2 (git+https://github.com/urbint/rust-rocksdb.git)" = "<none>"
 "checksum magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf0336886480e671965f794bc9b6fce88503563013d1bfb7a502c81fe3ac527"
 "checksum magenta-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "40d014c7011ac470ae28e2f76a02bfea4a8480f73e701353b49ad7a8d75f4699"
 "checksum make-cmd 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a8ca8afbe8af1785e09636acb5a41e08a765f5f0340568716c18a8700ba3c0d3"
@@ -240,7 +240,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "eb250fd207a4729c976794d03db689c9be1d634ab5a1c9da9492a13d8fecbcdf"
 "checksum rayon 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b614fe08b6665cb9a231d07ac1364b0ef3cb3698f1239ee0c4c3a88a524f54c8"
 "checksum rayon-core 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7febc28567082c345f10cddc3612c6ea020fc3297a1977d472cf9fdb73e6e493"
-"checksum rocksdb 0.7.0 (git+https://github.com/urbint/rust-rocksdb.git)" = "<none>"
+"checksum rocksdb 0.8.1 (git+https://github.com/urbint/rust-rocksdb.git)" = "<none>"
 "checksum rustler 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c9c618866bb92c22a30810b593809a41ee65640d82bca664954adcc2ed0a1cef"
 "checksum rustler_codegen 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d7627a6cea2d3aa1146eeed1f99c794f2dc01ab7b7072896a1561ed730bb024d"
 "checksum scopeguard 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c79eb2c3ac4bc2507cda80e7f3ac5b88bd8eae4c0914d5663e6a8933994be918"

--- a/test/rox_test.exs
+++ b/test/rox_test.exs
@@ -48,6 +48,16 @@ defmodule RoxTest do
       assert length(items) > 10
     end
 
+    test "stream_keys", %{db: db} do
+      Enum.each(0..9, & :ok = Rox.put(db, to_string(&1), &1))
+
+      items =
+        Rox.stream_keys(db, {:from, "0", :forward})
+        |> Enum.take(10)
+
+      assert ~w(0 1 2 3 4 5 6 7 8 9) == items
+    end
+
     test "delete", %{db: db} do
       assert :not_found = Rox.get(db, "delete_test")
       assert :ok = Rox.put(db, "delete_test", "some_val")


### PR DESCRIPTION
In addition to Rox.stream/2, add a Rox.stream_keys/2 function, which
optimizes over `stream` by avoiding decoding the values of the stream from
binary at each step of the iteration. There's a later optimization to be
had here by avoiding allocating the Erlang term *entirely*.