### PR TITLE
feat(): Allow creating database snapshots

### DIFF
--- a/lib/rox/column_family.ex
+++ b/lib/rox/column_family.ex
@@ -1,20 +1,22 @@
 defmodule Rox.ColumnFamily do
   @moduledoc """
   Struct module representing a handle for a column family within a database.
-  
+
   For working with the column family, see the functions in the top level
   `Rox` module.
-  
+
   Implements the `Collectable` and `Enumerable` protocols.
 
   """
 
-  alias Rox.DB
+  alias Rox.{DB, Snapshot}
 
   @typedoc "A reference to a RocksDB column family"
   @type t :: %__MODULE__{
-    db_resource: binary, cf_resource: binary,
-    db_reference: reference, name: binary,
+    db_resource: binary,
+    cf_resource: binary,
+    db_reference: reference,
+    name: binary,
   }
   defstruct [:db_reference, :db_resource, :cf_resource, :name]
 
@@ -23,8 +25,19 @@ defmodule Rox.ColumnFamily do
   @doc false
   def wrap_resource(%DB{resource: db_resource, reference: db_reference}, resource, name) do
     %__MODULE__{
-      db_resource: db_resource, db_reference: db_reference,
-      cf_resource: resource, name: name
+      db_resource: db_resource,
+      db_reference: db_reference,
+      cf_resource: resource,
+      name: name
+    }
+  end
+
+  def wrap_resource(%Snapshot{resource: db_resource, reference: db_reference}, resource, name) do
+    %__MODULE__{
+      db_resource: db_resource,
+      db_reference: db_reference,
+      cf_resource: resource,
+      name: name
     }
   end
 

--- a/lib/rox/db.ex
+++ b/lib/rox/db.ex
@@ -1,10 +1,10 @@
 defmodule Rox.DB do
   @moduledoc """
   Struct module representing a handle for a database.
-  
+
   For working with the database, see the functions in the top
   level `Rox` module.
-  
+
   Implements the `Collectable` and `Enumerable` protocols.
 
   """

--- a/lib/rox/native.ex
+++ b/lib/rox/native.ex
@@ -11,6 +11,14 @@ defmodule Rox.Native do
     end
   end
 
+  def create_snapshot(_) do
+    case :erlang.phash2(1, 1) do
+      0 -> raise "Nif not loaded"
+      1 -> {:ok, ""}
+      2 -> {:error, ""}
+    end
+  end
+
   def count(_) do
     case :erlang.phash2(1, 1) do
       0 -> raise "Nif not loaded"

--- a/lib/rox/snapshot.ex
+++ b/lib/rox/snapshot.ex
@@ -1,0 +1,58 @@
+defmodule Rox.Snapshot do
+  @moduledoc """
+  Struct module representing a handle for a database snapshot.
+
+  Snapshots support all read operations that a `Rox.DB` supports, and implement `Enumerable`, but
+  not `Collectable`
+
+  """
+
+  alias Rox.DB
+
+
+
+  @typedoc "A reference to a RocksDB database snapshot"
+  @type t :: %__MODULE__{
+    resource: binary,
+    reference: reference,
+    db: DB.t
+  }
+
+  @enforce_keys [:resource, :reference, :db]
+  defstruct [
+    :resource,
+    :reference,
+    :db
+  ]
+
+  @doc false
+  def wrap_resource(%DB{} = db, resource) do
+    %__MODULE__{resource: resource, reference: make_ref(), db: db}
+  end
+
+  defimpl Inspect do
+    import Inspect.Algebra
+
+    def inspect(handle, opts) do
+      "#Rox.Snapshot<#{to_doc(handle.reference, opts)}>"
+    end
+  end
+
+  defimpl Enumerable do
+    def count(snapshot), do: {:ok, Rox.count(snapshot)}
+
+    def member?(snapshot, {key, val}) do
+      with {:ok, stored_val} <- Rox.get(snapshot, key) do
+        stored_val == {:ok, val}
+      else
+        _ -> {:ok, false}
+      end
+    end
+    def member?(_, _), do: {:ok, false}
+
+    def reduce(snapshot, cmd, fun) do
+      Rox.stream(snapshot)
+      |> Enumerable.reduce(cmd, fun)
+    end
+  end
+end


### PR DESCRIPTION
Add a `create_snapshot` function, that creates a RocksDB database
snapshot from the given database handle and returns it.

There's a pretty fantastic amount of horribly unsafe Rust going on here -
 primarily caused by the fact that the rust-rocksdb snapshot type is,
unlike Iterator or ColumnFamily or any of the other types that really
*should* be, parametrized by the lifetime of a borrowed reference to its
owner database. The abstraction provided by Rustler doesn't allow
non-static lifetime-parametrized struct types to be returned back to
Erlang as resources, for some technical type-mismatch reasons but also
practically because relying on the Erlang garbage collector to free our
stuff doesn't fit at *all* with rust's lifetime model.

The workaround here is to use `mem::transmute` (I told you it was
crazy...) to turn the snapshot reference from a `Snapshot<'a>` to a
`Snapshot<'static>`, and pass *that*, along with a held ARC reference to
the owning DB, to Erlang, and then when the Erlang GC decides it's time
to free the snapshot, go *back* to a first unbounded, then elided
lifetime to force the snapshot to be dropped.

I've done some cursory checking and regular operation (creating a
snapshot from a process then letting that process die) appears to not
leak the snapshots, but we should keep an eye on this to make sure we
don't have any leaks (or worse) in the future.

As a further note, the bit that parses out the argument for the NIFs
that now accept *either* a DB or a snapshot is a little mucky - that
should be revisited at a later date to see if we can clean it up a
little.