### PR TITLE
Update install documentation to target rox ~> 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rustler (Rust) powered erlang NIFs for RocksDB
 ```ex
 def deps do
   [
-    {:rox, "~> 1.0"},
+    {:rox, "~> 2.0"},
   ]
 end
 ```


### PR DESCRIPTION
👋

I ran into the same error as described in [issue #10](https://github.com/urbint/rox/issues/10) when installing but changing the dependency to "~> 2.0" fixed it for me.

 Thanks for building Rox!

-M